### PR TITLE
fix: VPResponse.VPToken as map[string][]string per OID4VP DCQL spec

### DIFF
--- a/internal/apigw/apiv1/handlers_verifier.go
+++ b/internal/apigw/apiv1/handlers_verifier.go
@@ -211,11 +211,12 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	}
 
 	// Extract VP Token from the map using the credential query ID
-	vpToken, ok := vpResponse.VPToken[credQueryID]
-	if !ok {
+	vpTokens, ok := vpResponse.VPToken[credQueryID]
+	if !ok || len(vpTokens) == 0 {
 		c.log.Error(nil, "VP Token not found for credential query", "query_id", credQueryID, "available_keys", vpResponse.VPToken)
 		return nil, fmt.Errorf("VP Token not found for credential query: %s", credQueryID)
 	}
+	vpToken := vpTokens[0]
 
 	// Prepare response parameters
 	responseParams := &openid4vp.ResponseParameters{

--- a/internal/verifier/apiv1/handlers_verification.go
+++ b/internal/verifier/apiv1/handlers_verification.go
@@ -139,11 +139,12 @@ func (c *Client) VerificationDirectPost(ctx context.Context, req *VerificationDi
 	credentialCaches := make([]sdjwtvc.CredentialCache, 0, len(authCtx.Scopes))
 
 	for _, scope := range authCtx.Scopes {
-		vpToken, ok := vpResponse.VPToken[scope]
-		if !ok {
+		vpTokens, ok := vpResponse.VPToken[scope]
+		if !ok || len(vpTokens) == 0 {
 			c.log.Error(nil, "VP token not found for scope", "scope", scope)
 			return nil, fmt.Errorf("VP token not found for scope: %s", scope)
 		}
+		vpToken := vpTokens[0]
 
 		responseParams := &openid4vp.ResponseParameters{}
 		responseParams.State = vpResponse.State

--- a/pkg/openid4vp/response_parameters.go
+++ b/pkg/openid4vp/response_parameters.go
@@ -8,8 +8,8 @@ import (
 )
 
 type VPResponse struct {
-	VPToken map[string]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
-	State   string            `json:"state,omitempty" bson:"state" validate:"required"`
+	VPToken map[string][]string `json:"vp_token,omitempty" bson:"vp_token" validate:"required"`
+	State   string              `json:"state,omitempty" bson:"state" validate:"required"`
 }
 
 type ResponseParameters struct {

--- a/pkg/openid4vp/response_parameters_additional_test.go
+++ b/pkg/openid4vp/response_parameters_additional_test.go
@@ -224,9 +224,9 @@ func TestResponseParameters_RoundTrip(t *testing.T) {
 func TestVPResponse(t *testing.T) {
 	t.Run("create and marshal", func(t *testing.T) {
 		vpResp := VPResponse{
-			VPToken: map[string]string{
-				"credential_1": "token1",
-				"credential_2": "token2",
+			VPToken: map[string][]string{
+				"credential_1": {"token1"},
+				"credential_2": {"token2"},
 			},
 			State: "test-state",
 		}


### PR DESCRIPTION
## Summary

Per OID4VP §6.3 with DCQL, `vp_token` values are arrays of Verifiable Presentations keyed by credential query ID. The previous `map[string]string` type caused `json.Unmarshal` to fail when a spec-compliant wallet sends array values, resulting in errors like `failed to unmarshal decrypted JWE`.

## Changes

- Change `VPToken` from `map[string]string` to `map[string][]string` in `VPResponse`
- Update API gateway handler to unwrap first token from array
- Update verifier handler with same unwrap logic
- Update tests to use new type

## Notes

Rebased version of SUNET/vc#386 targeting `release/sirosid/v0.5.0`.

Fixes #365