### PR TITLE
fix: omit nonce claim from ID token when not provided in authorize request

### DIFF
--- a/internal/verifier/apiv1/handler_oidc.go
+++ b/internal/verifier/apiv1/handler_oidc.go
@@ -403,12 +403,16 @@ func (c *Client) generateIDToken(ctx context.Context, authCtx *cache.Authorizati
 	idTokenTTL := time.Duration(c.cfg.Verifier.Outbound.OIDCProvider.IDTokenDuration) * time.Second
 
 	claims := jwt.MapClaims{
-		"iss":   c.cfg.Verifier.Outbound.OIDCProvider.Issuer,
-		"sub":   sub,
-		"aud":   client.ClientID,
-		"exp":   now.Add(idTokenTTL).Unix(),
-		"iat":   now.Unix(),
-		"nonce": authCtx.Nonce,
+		"iss": c.cfg.Verifier.Outbound.OIDCProvider.Issuer,
+		"sub": sub,
+		"aud": client.ClientID,
+		"exp": now.Add(idTokenTTL).Unix(),
+		"iat": now.Unix(),
+	}
+
+	// Only include nonce claim if a nonce was provided in the authorization request
+	if authCtx.Nonce != "" {
+		claims["nonce"] = authCtx.Nonce
 	}
 
 	// Add verified claims, but never overwrite reserved OIDC claims

--- a/internal/verifier/apiv1/handler_oidc_test.go
+++ b/internal/verifier/apiv1/handler_oidc_test.go
@@ -1067,6 +1067,53 @@ func TestGenerateIDToken(t *testing.T) {
 	assert.Equal(t, "john@example.com", claims["email"])
 }
 
+// TestGenerateIDToken_NoNonce tests that nonce claim is omitted when no nonce was provided
+func TestGenerateIDToken_NoNonce(t *testing.T) {
+	ctx := t.Context()
+
+	client, _ := CreateTestClientWithMock(nil)
+	client.cfg.Verifier.Outbound.OIDCProvider.Issuer = "https://issuer.example.com"
+	client.cfg.Verifier.Outbound.OIDCProvider.IDTokenDuration = 3600
+	client.cfg.Verifier.Outbound.OIDCProvider.SubjectType = "public"
+	client.cfg.Verifier.Outbound.OIDCProvider.SubjectSalt = "test-salt"
+
+	// Set up signing key
+	key := generateTestRSAKey(t)
+	require.NoError(t, client.SetSigningKeyForTesting(key))
+
+	authCtx := &cache.AuthorizationContext{
+		SessionID: "session-1",
+		ClientID:  "test-client",
+		Nonce:     "",
+		WalletID:  "wallet-123",
+		VerifiedClaims: map[string]any{
+			"name": "John Doe",
+		},
+	}
+
+	dbClient := &db.Client{
+		ClientID: "test-client",
+	}
+
+	idToken, err := client.generateIDToken(ctx, authCtx, dbClient)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, idToken)
+
+	// Parse and verify token
+	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+		return &key.PublicKey, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, token.Valid)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+
+	// Verify nonce claim is NOT present when no nonce was provided
+	_, nonceExists := claims["nonce"]
+	assert.False(t, nonceExists, "nonce claim should not be present when no nonce was provided in the authorize request")
+}
+
 // TestAuthenticateOIDCClient tests client authentication
 func TestAuthenticateOIDCClient(t *testing.T) {
 	client, _ := CreateTestClientWithMock(nil)


### PR DESCRIPTION
## Summary

Fixes #9

The verifier's `generateIDToken()` unconditionally included a `nonce` claim in the ID token, even when no `nonce` parameter was provided in the `/authorize` request. This resulted in an empty string `nonce` claim (`"nonce": ""`), which violates [OIDC Core Section 3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) and causes Auth0 (and potentially other OIDC RPs) to reject the token.

## Changes

- **`internal/verifier/apiv1/handler_oidc.go`**: Only add the `nonce` claim to the ID token when `authCtx.Nonce` is non-empty
- **`internal/verifier/apiv1/handler_oidc_test.go`**: Add `TestGenerateIDToken_NoNonce` test to verify the `nonce` claim is omitted when no nonce was provided in the authorize request

## Testing

- Existing `TestGenerateIDToken` passes (nonce present case)
- New `TestGenerateIDToken_NoNonce` passes (nonce absent case)
- Full `apiv1` test suite passes