### PR TITLE
ci: migrate to reusable Docker workflow for multi-arch builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,7 +11,7 @@ name: Build and Publish Docker Images
 
 on:
   push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+    tags: ['v[0-9]*.[0-9]*.[0-9]*']
   workflow_dispatch:
     inputs:
       git_ref:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,84 @@
+name: Build and Publish Docker Images
+
+# Builds multi-arch container images for all vc services using the
+# sirosfoundation reusable Docker workflow.
+#
+# Triggers:
+#   - Semver tags (v*.*.*): automatic build and push
+#   - workflow_dispatch: manual build from any git ref
+#
+# Images: ghcr.io/sirosfoundation/vc/{verifier,registry,apigw,issuer}
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (tag, branch, or SHA)'
+        required: true
+        default: 'main'
+      image_tag:
+        description: 'Custom image tag (auto-derived from ref if empty)'
+        required: false
+
+jobs:
+  verifier:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: sirosfoundation/vc/verifier
+      dockerfile: ./dockerfiles/worker
+      build-args: |
+        SERVICE_NAME=verifier
+        BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+      custom-ref: ${{ inputs.git_ref || '' }}
+      custom-tag: ${{ inputs.image_tag || '' }}
+
+  registry:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: sirosfoundation/vc/registry
+      dockerfile: ./dockerfiles/worker
+      build-args: |
+        SERVICE_NAME=registry
+        BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+      custom-ref: ${{ inputs.git_ref || '' }}
+      custom-tag: ${{ inputs.image_tag || '' }}
+
+  apigw:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: sirosfoundation/vc/apigw
+      dockerfile: ./dockerfiles/worker
+      build-args: |
+        SERVICE_NAME=apigw
+        BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+      custom-ref: ${{ inputs.git_ref || '' }}
+      custom-tag: ${{ inputs.image_tag || '' }}
+
+  issuer:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: sirosfoundation/vc/issuer
+      dockerfile: ./dockerfiles/worker
+      build-args: |
+        SERVICE_NAME=issuer
+        BUILDTAG=${{ inputs.image_tag || github.ref_name }}
+      custom-ref: ${{ inputs.git_ref || '' }}
+      custom-tag: ${{ inputs.image_tag || '' }}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ WORKER_SERVICES         := verifier registry apigw issuer
 DOCKER_REGISTRY         := docker.sunet.se/iam_vc
 DOCKER_BUILD_FLAGS      := 
 GO_BUILD_TAGS           ?=
+GOBUILD_IMAGE           ?=
 
 # Release Guard Configuration
 _RELEASE_MODE           ?=
@@ -412,6 +413,7 @@ docker-build-$(1): _check-reserved-tag ## Build Docker image for $(1)
 	docker build --build-arg SERVICE_NAME=$(1) \
 		$$(if $$(filter apigw,$(1)),--build-arg BUILDTAG=$$(VERSION)) \
 		$$(if $$(GO_BUILD_TAGS),--build-arg GO_BUILD_TAGS=$$(GO_BUILD_TAGS)) \
+		$$(if $$(GOBUILD_IMAGE),--build-arg GOBUILD_IMAGE=$$(GOBUILD_IMAGE)) \
 		--tag $$(call docker-tag,$(1),$$(VERSION)) \
 		--file dockerfiles/worker .
 
@@ -424,6 +426,7 @@ docker-build-issuer-hsm: _check-reserved-tag ## Build issuer Docker image with P
 	$(info Docker building issuer with PKCS#11 HSM support, tag: $(VERSION))
 	docker build --build-arg SERVICE_NAME=issuer --build-arg BUILDTAG=$(VERSION) \
 		--build-arg GO_BUILD_TAGS=$(PKCS11_TAG) \
+		$(if $(GOBUILD_IMAGE),--build-arg GOBUILD_IMAGE=$(GOBUILD_IMAGE)) \
 		--tag $(call docker-tag,issuer-hsm,$(VERSION)) \
 		--file dockerfiles/worker .
 

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -1,5 +1,16 @@
+# Build tools stage — installs protobuf compiler, swagger, and gRPC codegen.
+# Inlined from dockerfiles/gobuild so the Dockerfile is self-contained.
+# Use GOBUILD_IMAGE to override with a pre-built image for faster local builds:
+#   docker build --build-arg GOBUILD_IMAGE=docker.sunet.se/iam_vc/gobuild:local ...
+ARG GOBUILD_IMAGE=golang:1.26.4
+FROM ${GOBUILD_IMAGE} AS gobuild
+WORKDIR /go/src/app
+COPY Makefile .
+RUN make install-tools
+RUN make clean-apt-cache
+
 # Compile
-FROM docker.sunet.se/iam_vc/gobuild:local AS builder
+FROM gobuild AS builder
 
 ARG SERVICE_NAME
 ARG BUILDTAG
@@ -20,9 +31,14 @@ RUN make proto-${SERVICE_NAME}
 
 # Build with caching for both build cache and module cache
 # GO_BUILD_TAGS is optional - if set, adds -tags flag
+# CGO is disabled for static builds; enabled when build tags (e.g. pkcs11) require it
+# TARGETARCH is automatically set by Docker buildx for multi-platform builds;
+# defaults to amd64 for plain docker build.
+ARG CGO_ENABLED=0
+ARG TARGETARCH=amd64
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    GOOS=linux GOARCH=amd64 go build -v ${GO_BUILD_TAGS:+-tags "$GO_BUILD_TAGS"} -o bin/vc_$SERVICE_NAME -ldflags \
+    CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH} go build -v ${GO_BUILD_TAGS:+-tags "$GO_BUILD_TAGS"} -o bin/vc_$SERVICE_NAME -ldflags \
     "-X vc/pkg/model.BuildVariableGitCommit=$(git rev-list -1 HEAD) \
     -X vc/pkg/model.BuildVariableGitBranch=$(git rev-parse --abbrev-ref HEAD) \
     -X vc/pkg/model.BuildVariableTimestamp=$(date +'%F:T%TZ') \

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -3,13 +3,14 @@
 # Use GOBUILD_IMAGE to override with a pre-built image for faster local builds:
 #   docker build --build-arg GOBUILD_IMAGE=docker.sunet.se/iam_vc/gobuild:local ...
 ARG GOBUILD_IMAGE=golang:1.26.4
-FROM ${GOBUILD_IMAGE} AS gobuild
+FROM --platform=$BUILDPLATFORM ${GOBUILD_IMAGE} AS gobuild
 WORKDIR /go/src/app
 COPY Makefile .
 RUN make install-tools
 RUN make clean-apt-cache
 
-# Compile
+# Compile — pinned to BUILDPLATFORM so cross-compilation works even
+# when GOBUILD_IMAGE is single-arch; TARGETARCH drives GOARCH below.
 FROM gobuild AS builder
 
 ARG SERVICE_NAME
@@ -32,8 +33,8 @@ RUN make proto-${SERVICE_NAME}
 # Build with caching for both build cache and module cache
 # GO_BUILD_TAGS is optional - if set, adds -tags flag
 # CGO is disabled for static builds; enabled when build tags (e.g. pkcs11) require it
-# TARGETARCH is automatically set by Docker buildx for multi-platform builds;
-# defaults to amd64 for plain docker build.
+# TARGETARCH is set by BuildKit to the target platform (e.g. amd64, arm64).
+# The explicit default ensures plain 'docker build' without BuildKit still works.
 ARG CGO_ENABLED=0
 ARG TARGETARCH=amd64
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/dockerfiles/worker
+++ b/dockerfiles/worker
@@ -32,7 +32,8 @@ RUN make proto-${SERVICE_NAME}
 
 # Build with caching for both build cache and module cache
 # GO_BUILD_TAGS is optional - if set, adds -tags flag
-# CGO is disabled for static builds; enabled when build tags (e.g. pkcs11) require it
+# CGO defaults to disabled for static builds. Pass --build-arg CGO_ENABLED=1
+# for features that require CGO (e.g. pkcs11 HSM support).
 # TARGETARCH is set by BuildKit to the target platform (e.g. amd64, arm64).
 # The explicit default ensures plain 'docker build' without BuildKit still works.
 ARG CGO_ENABLED=0


### PR DESCRIPTION
## Summary

Replace the per-release-branch Docker workflow with a single tag-triggered workflow on main that calls the sirosfoundation reusable Docker build workflow.

## What this replaces

Previously, Joel's `docker-build-publish.yml` had to be cherry-picked to each `release/sirosid/*` branch. This PR eliminates that requirement.

## How it works

Tag-triggered workflows always run from the default branch (`main`), so:
- Upstream tags (`v0.6.1`) → builds automatically
- Sirosid sub-patch tags (`v0.6.1-sirosid.0`) → builds automatically
- Manual builds → `workflow_dispatch` with any git ref

No cherry-picking needed.

## New capabilities (vs. current)

| Feature | Before | After |
|---------|--------|-------|
| Multi-arch | amd64 only | amd64 + arm64 |
| Trivy CVE scan | No | Yes, per service |
| VEX suppression | No | Org + repo level |
| Build cache | No | GHA cache per service |
| Manual dispatch | No | Yes |
| Cherry-pick per release | Required | Not needed |

## Images

`ghcr.io/sirosfoundation/vc/{verifier,registry,apigw,issuer}` — same naming as before.

## Prerequisites

Includes Dockerfile and Makefile changes from upstream PRs:
- SUNET/vc#473 (TARGETARCH for multi-arch)
- SUNET/vc#474 (inline gobuild for self-contained builds)

## Note

The existing `docker-build-publish.yml` on `release/sirosid/*` branches can be removed once this is validated.