### PR TITLE
feat: add W3C Digital Credentials API support via @sirosfoundation/dc-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ swagger-verifier: ## Generate verifier Swagger docs
 	swag init -d internal/verifier/apiv1/ -g client.go --output docs/verifier $(SWAGGER_OPTS)
 
 swagger-apigw: ## Generate apigw Swagger docs
-	swag init -d internal/apigw/apiv1/,pkg/helpers,pkg/model,pkg/vcclient,pkg/openid4vci,pkg/oauth2,internal/gen/issuer/apiv1_issuer -g client.go --output docs/apigw $(SWAGGER_OPTS)
+	swag init -d internal/apigw/apiv1/,pkg/helpers,pkg/model,pkg/vcclient,pkg/openid4vci,pkg/openid4vp,pkg/oauth2,internal/gen/issuer/apiv1_issuer -g client.go --output docs/apigw $(SWAGGER_OPTS)
 
 swagger-issuer: ## Generate issuer Swagger docs
 	swag init -d internal/issuer/apiv1/ -g client.go --output docs/issuer $(SWAGGER_OPTS)

--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -1170,9 +1170,6 @@ const docTemplate = `{
                 },
                 "credential_offer_url": {
                     "type": "string"
-                },
-                "qr": {
-                    "$ref": "#/definitions/openid4vp.QRReply"
                 }
             }
         },
@@ -2288,21 +2285,6 @@ const docTemplate = `{
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
-                    "type": "string"
-                }
-            }
-        },
-        "openid4vp.QRReply": {
-            "type": "object",
-            "required": [
-                "base64_image",
-                "uri"
-            ],
-            "properties": {
-                "base64_image": {
-                    "type": "string"
-                },
-                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/docs.go
+++ b/docs/apigw/docs.go
@@ -336,6 +336,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/datastore/preauth_offer": {
+            "post": {
+                "description": "Generate a pre-authorized credential offer for a datastore document",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "vc-platform"
+                ],
+                "summary": "DatastorePreAuthOffer",
+                "operationId": "datastore-preauth-offer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Document not found",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datastore/resolve": {
             "post": {
                 "description": "Resolve identity attributes to documents",
@@ -1112,6 +1159,45 @@ const docTemplate = `{
                 },
                 "valid_to": {
                     "type": "integer"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferReply": {
+            "type": "object",
+            "properties": {
+                "credential_offer": {
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
+                },
+                "credential_offer_url": {
+                    "type": "string"
+                },
+                "qr": {
+                    "$ref": "#/definitions/openid4vp.QRReply"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "scope"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "description": "required: true\nexample: SUNET",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "document_id": {
+                    "description": "required: true\nexample: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "scope": {
+                    "description": "required: true\nexample: pid",
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -2202,6 +2288,21 @@ const docTemplate = `{
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vp.QRReply": {
+            "type": "object",
+            "required": [
+                "base64_image",
+                "uri"
+            ],
+            "properties": {
+                "base64_image": {
+                    "type": "string"
+                },
+                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -1162,9 +1162,6 @@
                 },
                 "credential_offer_url": {
                     "type": "string"
-                },
-                "qr": {
-                    "$ref": "#/definitions/openid4vp.QRReply"
                 }
             }
         },
@@ -2280,21 +2277,6 @@
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
-                    "type": "string"
-                }
-            }
-        },
-        "openid4vp.QRReply": {
-            "type": "object",
-            "required": [
-                "base64_image",
-                "uri"
-            ],
-            "properties": {
-                "base64_image": {
-                    "type": "string"
-                },
-                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.json
+++ b/docs/apigw/swagger.json
@@ -328,6 +328,53 @@
                 }
             }
         },
+        "/api/v1/datastore/preauth_offer": {
+            "post": {
+                "description": "Generate a pre-authorized credential offer for a datastore document",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "vc-platform"
+                ],
+                "summary": "DatastorePreAuthOffer",
+                "operationId": "datastore-preauth-offer",
+                "parameters": [
+                    {
+                        "description": " ",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/apiv1.DatastorePreAuthOfferReply"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Document not found",
+                        "schema": {
+                            "$ref": "#/definitions/helpers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/datastore/resolve": {
             "post": {
                 "description": "Resolve identity attributes to documents",
@@ -1104,6 +1151,45 @@
                 },
                 "valid_to": {
                     "type": "integer"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferReply": {
+            "type": "object",
+            "properties": {
+                "credential_offer": {
+                    "$ref": "#/definitions/openid4vci.CredentialOfferResult"
+                },
+                "credential_offer_url": {
+                    "type": "string"
+                },
+                "qr": {
+                    "$ref": "#/definitions/openid4vp.QRReply"
+                }
+            }
+        },
+        "apiv1.DatastorePreAuthOfferRequest": {
+            "type": "object",
+            "required": [
+                "authentic_source",
+                "document_id",
+                "scope"
+            ],
+            "properties": {
+                "authentic_source": {
+                    "description": "required: true\nexample: SUNET",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "document_id": {
+                    "description": "required: true\nexample: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8",
+                    "type": "string",
+                    "maxLength": 128
+                },
+                "scope": {
+                    "description": "required: true\nexample: pid",
+                    "type": "string",
+                    "maxLength": 128
                 }
             }
         },
@@ -2194,6 +2280,21 @@
                 },
                 "token_type": {
                     "description": "TokenType REQUIRED.  The type of the token issued as described in Section 7.1.  Value is case insensitive.",
+                    "type": "string"
+                }
+            }
+        },
+        "openid4vp.QRReply": {
+            "type": "object",
+            "required": [
+                "base64_image",
+                "uri"
+            ],
+            "properties": {
+                "base64_image": {
+                    "type": "string"
+                },
+                "uri": {
                     "type": "string"
                 }
             }

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -145,8 +145,6 @@ definitions:
         $ref: '#/definitions/openid4vci.CredentialOfferResult'
       credential_offer_url:
         type: string
-      qr:
-        $ref: '#/definitions/openid4vp.QRReply'
     type: object
   apiv1.DatastorePreAuthOfferRequest:
     properties:
@@ -1130,16 +1128,6 @@ definitions:
     - access_token
     - expires_in
     - token_type
-    type: object
-  openid4vp.QRReply:
-    properties:
-      base64_image:
-        type: string
-      uri:
-        type: string
-    required:
-    - base64_image
-    - uri
     type: object
   vcclient.UploadRequest:
     properties:

--- a/docs/apigw/swagger.yaml
+++ b/docs/apigw/swagger.yaml
@@ -139,6 +139,40 @@ definitions:
     required:
     - identity_mapping_id
     type: object
+  apiv1.DatastorePreAuthOfferReply:
+    properties:
+      credential_offer:
+        $ref: '#/definitions/openid4vci.CredentialOfferResult'
+      credential_offer_url:
+        type: string
+      qr:
+        $ref: '#/definitions/openid4vp.QRReply'
+    type: object
+  apiv1.DatastorePreAuthOfferRequest:
+    properties:
+      authentic_source:
+        description: |-
+          required: true
+          example: SUNET
+        maxLength: 128
+        type: string
+      document_id:
+        description: |-
+          required: true
+          example: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8
+        maxLength: 128
+        type: string
+      scope:
+        description: |-
+          required: true
+          example: pid
+        maxLength: 128
+        type: string
+    required:
+    - authentic_source
+    - document_id
+    - scope
+    type: object
   apiv1.DatastoreResolveReply:
     properties:
       authentic_source_person_id:
@@ -1097,6 +1131,16 @@ definitions:
     - expires_in
     - token_type
     type: object
+  openid4vp.QRReply:
+    properties:
+      base64_image:
+        type: string
+      uri:
+        type: string
+    required:
+    - base64_image
+    - uri
+    type: object
   vcclient.UploadRequest:
     properties:
       document_data:
@@ -1331,6 +1375,37 @@ paths:
           schema:
             $ref: '#/definitions/helpers.ErrorResponse'
       summary: DatastoreList
+      tags:
+      - vc-platform
+  /api/v1/datastore/preauth_offer:
+    post:
+      consumes:
+      - application/json
+      description: Generate a pre-authorized credential offer for a datastore document
+      operationId: datastore-preauth-offer
+      parameters:
+      - description: ' '
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/apiv1.DatastorePreAuthOfferRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/apiv1.DatastorePreAuthOfferReply'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/helpers.ErrorResponse'
+        "404":
+          description: Document not found
+          schema:
+            $ref: '#/definitions/helpers.ErrorResponse'
+      summary: DatastorePreAuthOffer
       tags:
       - vc-platform
   /api/v1/datastore/resolve:

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -619,8 +619,9 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 		CreatedAt:  time.Now(),
 		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
 		Scopes:     []string{req.Scope},
-		Nonce:      nonce,
-		DataSource: string(model.DataSourceDatastore),
+		Nonce:        nonce,
+		DataSource:   string(model.DataSourceDatastore),
+		AuthProvider: model.AuthProviderDatastore,
 	}
 	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
 		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -3,7 +3,6 @@ package apiv1
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/SUNET/vc/internal/apigw/db"
@@ -12,11 +11,9 @@ import (
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
 	"github.com/SUNET/vc/pkg/openid4vci"
-	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/google/uuid"
-	"github.com/skip2/go-qrcode"
 )
 
 // DatastoreUploadReply is the reply for a document upload
@@ -562,11 +559,10 @@ type DatastorePreAuthOfferRequest struct {
 	DocumentID string `json:"document_id" validate:"required,max=128,printascii"`
 }
 
-// DatastorePreAuthOfferReply is the reply containing a credential offer and QR code
+// DatastorePreAuthOfferReply is the reply containing a credential offer
 type DatastorePreAuthOfferReply struct {
 	CredentialOffer    *openid4vci.CredentialOfferResult `json:"credential_offer"`
 	CredentialOfferURL string                            `json:"credential_offer_url"`
-	QR                 *openid4vp.QRReply                `json:"qr,omitempty"`
 }
 
 // DatastorePreAuthOffer generates a pre-authorized credential offer for a specific
@@ -645,21 +641,9 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 	}
 	credentialOfferURL := fmt.Sprintf("openid-credential-offer://?%s", string(credentialOfferEncoded))
 
-	// Generate QR code for the offer URL
-	u, err := url.Parse(credentialOfferURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse credential offer URL: %w", err)
-	}
-	qr, err := openid4vp.GenerateQR(u, qrcode.Medium, 256)
-	if err != nil {
-		c.log.Debug("failed to generate QR code", "error", err)
-		// QR generation failure is non-fatal; return the offer without the QR
-	}
-
 	reply := &DatastorePreAuthOfferReply{
 		CredentialOffer:    credentialOffer,
 		CredentialOfferURL: credentialOfferURL,
-		QR:                 qr,
 	}
 
 	c.log.Info("Pre-authorized credential offer created for datastore document",

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -3,13 +3,20 @@ package apiv1
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"time"
 
 	"github.com/SUNET/vc/internal/apigw/db"
+	"github.com/SUNET/vc/pkg/cache"
+	"github.com/SUNET/vc/pkg/crypto"
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vci"
+	"github.com/SUNET/vc/pkg/openid4vp"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/google/uuid"
+	"github.com/skip2/go-qrcode"
 )
 
 // DatastoreUploadReply is the reply for a document upload
@@ -535,6 +542,131 @@ func (c *Client) DatastoreSearch(ctx context.Context, req *DatastoreSearchReques
 	reply := &DatastoreSearchReply{
 		Data: docs,
 	}
+
+	return reply, nil
+}
+
+// DatastorePreAuthOfferRequest is the request for generating a pre-authorized credential offer
+// for a specific document in the datastore.
+type DatastorePreAuthOfferRequest struct {
+	// required: true
+	// example: SUNET
+	AuthenticSource string `json:"authentic_source" validate:"required,max=128,printascii"`
+
+	// required: true
+	// example: pid
+	Scope string `json:"scope" validate:"required,max=128,printascii"`
+
+	// required: true
+	// example: 7a00fe1a-3e1a-11ef-9272-fb906803d1b8
+	DocumentID string `json:"document_id" validate:"required,max=128,printascii"`
+}
+
+// DatastorePreAuthOfferReply is the reply containing a credential offer and QR code
+type DatastorePreAuthOfferReply struct {
+	CredentialOffer    *openid4vci.CredentialOfferResult `json:"credential_offer"`
+	CredentialOfferURL string                            `json:"credential_offer_url"`
+	QR                 *openid4vp.QRReply                `json:"qr,omitempty"`
+}
+
+// DatastorePreAuthOffer generates a pre-authorized credential offer for a specific
+// document in the datastore. This allows an admin or authentic source to create
+// a credential offer that a wallet can redeem without user authentication.
+//
+//	@Summary		DatastorePreAuthOffer
+//	@ID				datastore-preauth-offer
+//	@Description	Generate a pre-authorized credential offer for a datastore document
+//	@Tags			vc-platform
+//	@Accept			json
+//	@Produce		json
+//	@Success		200	{object}	DatastorePreAuthOfferReply	"Success"
+//	@Failure		400	{object}	helpers.ErrorResponse		"Bad Request"
+//	@Failure		404	{object}	helpers.ErrorResponse		"Document not found"
+//	@Param			req	body		DatastorePreAuthOfferRequest	true	" "
+//	@Router			/api/v1/datastore/preauth_offer [post]
+func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAuthOfferRequest) (*DatastorePreAuthOfferReply, error) {
+	// Look up the document from the datastore
+	doc, err := c.datastoreStore.GetByKey(ctx, req.AuthenticSource, req.Scope, req.DocumentID)
+	if err != nil {
+		return nil, fmt.Errorf("document not found: %w", err)
+	}
+
+	// Generate credential offer with pre-authorized code
+	credentialOffer, err := openid4vci.NewCredentialOffer(
+		c.cfg.APIGW.Delivery.CredentialOffers.IssuerURL,
+		req.Scope,
+		openid4vci.GrantTypePreAuthorizedCode,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate credential offer: %w", err)
+	}
+
+	preAuthCode := credentialOffer.ID
+
+	// Generate nonce for the authorization context
+	nonce, err := crypto.GenerateSecureToken(0, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	// Create and persist the authorization context so the wallet can redeem
+	// the offer via the token endpoint.
+	authCtx := &cache.AuthorizationContext{
+		SessionID:  preAuthCode,
+		Code:       preAuthCode,
+		Status:     "code_issued",
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+		Scopes:     []string{req.Scope},
+		Nonce:      nonce,
+		DataSource: string(model.DataSourceDatastore),
+		AuthorizationDetails: []openid4vci.AuthorizationDetailsParameter{
+			{
+				Type:                      "openid_credential",
+				CredentialConfigurationID: req.Scope,
+			},
+		},
+	}
+	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
+		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)
+	}
+
+	// Store the document data so the credential endpoint can issue the
+	// credential when the wallet redeems the offer.
+	if err := c.StoreVCIDocuments(ctx, preAuthCode, map[string]*model.CompleteDocument{req.AuthenticSource: doc}); err != nil {
+		return nil, fmt.Errorf("failed to store VCI documents: %w", err)
+	}
+
+	// Build the credential offer URL (inline offer, not by-reference)
+	offerParams := credentialOffer.CredentialOfferParameters
+	credentialOfferEncoded, err := offerParams.CredentialOffer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode credential offer: %w", err)
+	}
+	credentialOfferURL := fmt.Sprintf("openid-credential-offer://?%s", string(credentialOfferEncoded))
+
+	// Generate QR code for the offer URL
+	u, err := url.Parse(credentialOfferURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credential offer URL: %w", err)
+	}
+	qr, err := openid4vp.GenerateQR(u, qrcode.Medium, 256)
+	if err != nil {
+		c.log.Debug("failed to generate QR code", "error", err)
+		// QR generation failure is non-fatal; return the offer without the QR
+	}
+
+	reply := &DatastorePreAuthOfferReply{
+		CredentialOffer:    credentialOffer,
+		CredentialOfferURL: credentialOfferURL,
+		QR:                 qr,
+	}
+
+	c.log.Info("Pre-authorized credential offer created for datastore document",
+		"authentic_source", req.AuthenticSource,
+		"scope", req.Scope,
+		"document_id", req.DocumentID,
+		"offer_id", credentialOffer.ID)
 
 	return reply, nil
 }

--- a/internal/apigw/apiv1/handlers_datastore.go
+++ b/internal/apigw/apiv1/handlers_datastore.go
@@ -607,6 +607,11 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 
 	// Create and persist the authorization context so the wallet can redeem
 	// the offer via the token endpoint.
+	// Note: AuthorizationDetails is intentionally left empty. If set, the token
+	// endpoint would return authorization_details with credential_identifiers,
+	// which per OID4VCI spec forces the wallet to use credential_identifier
+	// (not credential_configuration_id) in the credential request. Most wallets
+	// use credential_configuration_id for pre-auth flows, so we keep it simple.
 	authCtx := &cache.AuthorizationContext{
 		SessionID:  preAuthCode,
 		Code:       preAuthCode,
@@ -616,12 +621,6 @@ func (c *Client) DatastorePreAuthOffer(ctx context.Context, req *DatastorePreAut
 		Scopes:     []string{req.Scope},
 		Nonce:      nonce,
 		DataSource: string(model.DataSourceDatastore),
-		AuthorizationDetails: []openid4vci.AuthorizationDetailsParameter{
-			{
-				Type:                      "openid_credential",
-				CredentialConfigurationID: req.Scope,
-			},
-		},
 	}
 	if err := c.cacheService.AuthContext.Save(ctx, authCtx); err != nil {
 		return nil, fmt.Errorf("failed to store pre-auth code: %w", err)

--- a/internal/apigw/apiv1/handlers_datastore_test.go
+++ b/internal/apigw/apiv1/handlers_datastore_test.go
@@ -981,10 +981,6 @@ func TestDatastorePreAuthOffer_Success(t *testing.T) {
 	assert.Contains(t, reply.CredentialOfferURL, "openid-credential-offer://")
 	assert.Contains(t, reply.CredentialOfferURL, "credential_offer")
 
-	// Verify QR code was generated
-	require.NotNil(t, reply.QR)
-	assert.NotEmpty(t, reply.QR.Base64Image)
-	assert.NotEmpty(t, reply.QR.URI)
 }
 
 func TestDatastorePreAuthOffer_DocumentNotFound(t *testing.T) {

--- a/internal/apigw/apiv1/handlers_datastore_test.go
+++ b/internal/apigw/apiv1/handlers_datastore_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SUNET/vc/internal/apigw/cache"
 	"github.com/SUNET/vc/pkg/helpers"
 	"github.com/SUNET/vc/pkg/logger"
 	"github.com/SUNET/vc/pkg/model"
+	"github.com/SUNET/vc/pkg/openid4vci"
 	"github.com/SUNET/vc/pkg/vcclient"
 
 	"github.com/stretchr/testify/assert"
@@ -914,4 +916,138 @@ func TestDatastoreDeleteNotFound(t *testing.T) {
 		AuthenticSource: "SUNET", Scope: "ehic", DocumentID: "no-such",
 	})
 	assert.Error(t, err)
+}
+
+// --- DatastorePreAuthOffer ---
+
+func newPreAuthOfferTestClient(t *testing.T) (*Client, *memoryDatastoreStore) {
+	t.Helper()
+	log, err := logger.New("test", "", false)
+	require.NoError(t, err)
+
+	datastore := newMemoryDatastoreStore()
+	authContextStore := cache.NewTestMemoryStore(10 * time.Minute)
+	docCache := cache.NewTestMemoryCache[map[string]*model.CompleteDocument](10 * time.Minute)
+
+	client := &Client{
+		log:            log,
+		datastoreStore: datastore,
+		cfg: &model.Cfg{
+			APIGW: &model.APIGW{
+				Delivery: model.APIGWDelivery{
+					CredentialOffers: model.CredentialOffers{
+						IssuerURL: "https://issuer.example.com",
+						Wallets:   map[string]model.CredentialOfferWallets{},
+					},
+				},
+			},
+		},
+		cacheService: &cache.Service{
+			AuthContext: authContextStore,
+			Document:    docCache,
+		},
+	}
+	return client, datastore
+}
+
+func TestDatastorePreAuthOffer_Success(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	seedDoc(t, datastore, "SUNET", "pid", "doc-1", []string{"person-1"}, map[string]any{
+		"family_name": "Doe",
+		"given_name":  "John",
+	})
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "doc-1",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, reply)
+
+	// Verify credential offer fields
+	assert.Equal(t, "https://issuer.example.com", reply.CredentialOffer.CredentialIssuer)
+	assert.Equal(t, []string{"pid"}, reply.CredentialOffer.CredentialConfigurationIDs)
+	assert.NotEmpty(t, reply.CredentialOffer.ID)
+
+	// Verify the offer contains a pre-authorized code grant
+	grant, ok := reply.CredentialOffer.Grants[openid4vci.GrantTypePreAuthorizedCode]
+	require.True(t, ok, "offer should contain pre-authorized_code grant")
+	require.NotNil(t, grant)
+
+	// Verify credential offer URL
+	assert.Contains(t, reply.CredentialOfferURL, "openid-credential-offer://")
+	assert.Contains(t, reply.CredentialOfferURL, "credential_offer")
+
+	// Verify QR code was generated
+	require.NotNil(t, reply.QR)
+	assert.NotEmpty(t, reply.QR.Base64Image)
+	assert.NotEmpty(t, reply.QR.URI)
+}
+
+func TestDatastorePreAuthOffer_DocumentNotFound(t *testing.T) {
+	client, _ := newPreAuthOfferTestClient(t)
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "nonexistent",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, reply)
+	assert.Contains(t, err.Error(), "document not found")
+}
+
+func TestDatastorePreAuthOffer_AuthContextPersisted(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	seedDoc(t, datastore, "SUNET", "ehic", "doc-2", []string{"person-2"}, map[string]any{
+		"card_number": "SE123456",
+	})
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "ehic",
+		DocumentID:      "doc-2",
+	})
+	require.NoError(t, err)
+
+	// Verify the auth context was saved by retrieving it
+	preAuthCode := reply.CredentialOffer.ID
+	authCtx, err := client.cacheService.AuthContext.GetByID(t.Context(), preAuthCode)
+	require.NoError(t, err)
+	require.NotNil(t, authCtx)
+
+	assert.Equal(t, preAuthCode, authCtx.SessionID)
+	assert.Equal(t, preAuthCode, authCtx.Code)
+	assert.Equal(t, "code_issued", string(authCtx.Status))
+	assert.Equal(t, []string{"ehic"}, authCtx.Scopes)
+	assert.Equal(t, "datastore", authCtx.DataSource)
+	assert.NotEmpty(t, authCtx.Nonce)
+	assert.True(t, authCtx.ExpiresAt > time.Now().Unix())
+}
+
+func TestDatastorePreAuthOffer_DocumentDataCached(t *testing.T) {
+	client, datastore := newPreAuthOfferTestClient(t)
+
+	docData := map[string]any{
+		"family_name": "Smith",
+		"given_name":  "Jane",
+		"birth_date":  "1990-05-15",
+	}
+	seedDoc(t, datastore, "SUNET", "pid", "doc-3", []string{"person-3"}, docData)
+
+	reply, err := client.DatastorePreAuthOffer(t.Context(), &DatastorePreAuthOfferRequest{
+		AuthenticSource: "SUNET",
+		Scope:           "pid",
+		DocumentID:      "doc-3",
+	})
+	require.NoError(t, err)
+
+	// Verify the document data was cached for the credential endpoint
+	preAuthCode := reply.CredentialOffer.ID
+	assert.True(t, client.HasVCIDocuments(t.Context(), preAuthCode))
 }

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -56,10 +56,11 @@ func (c *Client) ResolveIdentifier(ctx context.Context, authenticSource string, 
 }
 
 // requireIdentifier validates that a non-empty identifier exists for data sources
-// that require it. Assertion-based issuance allows an empty identifier because
-// all data comes from the trusted IdP claims.
+// that require it. Assertion-based and datastore-based issuance allow an empty
+// identifier because the data comes from trusted sources (IdP claims or
+// pre-uploaded documents) rather than identity-mapped lookups.
 func requireIdentifier(identifier string, dataSource model.DataSourceType) (string, error) {
-	if identifier == "" && dataSource != model.DataSourceAssertion {
+	if identifier == "" && dataSource != model.DataSourceAssertion && dataSource != model.DataSourceDatastore {
 		return "", errors.New("no identifier in auth context")
 	}
 	return identifier, nil

--- a/internal/apigw/apiv1/handlers_issuer.go
+++ b/internal/apigw/apiv1/handlers_issuer.go
@@ -281,7 +281,7 @@ func (c *Client) VCICredential(ctx context.Context, req *openid4vci.CredentialRe
 	c.log.Debug("VCICredential: retrieving credential data", "auth_provider", authContext.AuthProvider, "scope", scope, "session_id", authContext.SessionID, "doc_session_id", docSessionID)
 	// Retrieve credential data based on the auth provider used during authorization
 	switch authContext.AuthProvider {
-	case model.AuthProviderOpenID4VP, model.AuthProviderSAML, model.AuthProviderOIDC:
+	case model.AuthProviderOpenID4VP, model.AuthProviderSAML, model.AuthProviderOIDC, model.AuthProviderDatastore:
 		// Session-based auth providers: retrieve from session cache
 		docs, ok := c.cacheService.Document.Get(ctx, docSessionID)
 		if !ok || len(docs) == 0 {

--- a/internal/apigw/apiv1/handlers_issuer_assertion_test.go
+++ b/internal/apigw/apiv1/handlers_issuer_assertion_test.go
@@ -175,10 +175,10 @@ func TestAssertionDataSource_CredentialIssuance_AllowsEmptyIdentifier(t *testing
 			wantErr:    false,
 		},
 		{
-			name:       "datastore_empty_identifier_rejected",
+			name:       "datastore_empty_identifier_allowed",
 			dataSource: model.DataSourceDatastore,
 			identifier: "",
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name:       "external_api_empty_identifier_rejected",

--- a/internal/apigw/httpserver/api.go
+++ b/internal/apigw/httpserver/api.go
@@ -29,6 +29,7 @@ type Apiv1 interface {
 	DatastoreReplace(ctx context.Context, req *vcclient.UploadRequest) error
 	DatastoreSearch(ctx context.Context, req *apiv1.DatastoreSearchRequest) (*apiv1.DatastoreSearchReply, error)
 	DatastoreBulkUpload(ctx context.Context, req *apiv1.DatastoreBulkUploadRequest) (*apiv1.DatastoreBulkUploadReply, error)
+	DatastorePreAuthOffer(ctx context.Context, req *apiv1.DatastorePreAuthOfferRequest) (*apiv1.DatastorePreAuthOfferReply, error)
 
 	// identity mapping endpoints
 	IdentityMappingCreate(ctx context.Context, req *apiv1.IdentityMappingCreateRequest) (*apiv1.IdentityMappingCreateReply, error)

--- a/internal/apigw/httpserver/endpoints_datastore.go
+++ b/internal/apigw/httpserver/endpoints_datastore.go
@@ -214,3 +214,22 @@ func (s *Service) endpointDatastoreBulkUpload(ctx context.Context, c *gin.Contex
 
 	return reply, nil
 }
+
+func (s *Service) endpointDatastorePreAuthOffer(ctx context.Context, c *gin.Context) (any, error) {
+	ctx, span := s.tracer.Start(ctx, "httpserver:endpointDatastorePreAuthOffer")
+	defer span.End()
+
+	request := &apiv1.DatastorePreAuthOfferRequest{}
+	if err := s.httpHelpers.Binding.Request(ctx, c, request); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	reply, err := s.apiv1.DatastorePreAuthOffer(ctx, request)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	return reply, nil
+}

--- a/internal/apigw/httpserver/endpoints_datastore_test.go
+++ b/internal/apigw/httpserver/endpoints_datastore_test.go
@@ -394,6 +394,10 @@ func (u unimplementedApiv1) ListAuthenticSources(context.Context) ([]string, err
 	return nil, nil
 }
 
+func (u unimplementedApiv1) DatastorePreAuthOffer(context.Context, *apiv1.DatastorePreAuthOfferRequest) (*apiv1.DatastorePreAuthOfferReply, error) {
+	panic("not implemented")
+}
+
 func (u unimplementedApiv1) Health(context.Context, *apiv1_status.StatusRequest) (*apiv1_status.StatusReply, error) {
 	panic("not implemented")
 }

--- a/internal/apigw/httpserver/service.go
+++ b/internal/apigw/httpserver/service.go
@@ -262,6 +262,7 @@ func New(ctx context.Context, cfg *model.Cfg, apiv1 *apiv1.Client, tracer *trace
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodDelete, "/identity", http.StatusNoContent, s.endpointDatastoreDeleteIdentity)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodGet, "/search", http.StatusOK, s.endpointDatastoreSearch)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodPost, "/bulk", http.StatusOK, s.endpointDatastoreBulkUpload)
+	s.httpHelpers.Server.RegEndpoint(ctx, rgDatastore, http.MethodPost, "/preauth_offer", http.StatusOK, s.endpointDatastorePreAuthOffer)
 
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodGet, "/user/lookup", http.StatusOK, s.endpointUserLookup)
 	s.httpHelpers.Server.RegEndpoint(ctx, rgOAuthSession, http.MethodPost, "/user/cancel", http.StatusSeeOther, s.endpointUserCancel)

--- a/internal/verifier/apiv1/handlers_ui.go
+++ b/internal/verifier/apiv1/handlers_ui.go
@@ -52,12 +52,17 @@ type UIMetadataReply struct {
 	Credentials      map[string]*UICredentialInfo `json:"credentials"`
 	SupportedWallets map[string]string            `json:"supported_wallets"`
 	Presets          map[string]*UIPreset         `json:"presets,omitempty"`
+	// DCAPIEnabled mirrors verifier.digital_credentials.enable, so the UI only
+	// attempts the native W3C Digital Credentials API when an operator has
+	// opted in, rather than always trying it regardless of server config.
+	DCAPIEnabled bool `json:"dc_api_enabled"`
 }
 
 func (c *Client) UIMetadata(ctx context.Context) (*UIMetadataReply, error) {
 	reply := &UIMetadataReply{
 		Credentials:      make(map[string]*UICredentialInfo),
 		SupportedWallets: c.cfg.Verifier.SupportedWallets,
+		DCAPIEnabled:     c.cfg.Verifier.DigitalCredentials.Enable,
 	}
 
 	for scope, constructor := range c.cfg.Common.CredentialMetadata {

--- a/internal/verifier/apiv1/handlers_ui_test.go
+++ b/internal/verifier/apiv1/handlers_ui_test.go
@@ -22,11 +22,13 @@ func TestUIMetadata(t *testing.T) {
 		name              string
 		credentials       map[string]*model.CredentialMetadata
 		supportedWallets  map[string]string
+		dcAPIEnabled      bool
 		expectCredentials int
 		expectWallets     int
 	}{
 		{
-			name: "with credentials and wallets",
+			name:         "with credentials and wallets",
+			dcAPIEnabled: true,
 			credentials: map[string]*model.CredentialMetadata{
 				"pid": {
 					VCTMFilePath: "/path/to/vctm",
@@ -55,7 +57,8 @@ func TestUIMetadata(t *testing.T) {
 			expectWallets:     0,
 		},
 		{
-			name: "credentials only",
+			name:         "credentials only",
+			dcAPIEnabled: true,
 			credentials: map[string]*model.CredentialMetadata{
 				"ehic": {
 					VCTM: &sdjwtvc.VCTM{VCT: "urn:eudi:ehic:1"},
@@ -74,7 +77,8 @@ func TestUIMetadata(t *testing.T) {
 					CredentialMetadata: tt.credentials,
 				},
 				Verifier: &model.Verifier{
-					SupportedWallets: tt.supportedWallets,
+					SupportedWallets:   tt.supportedWallets,
+					DigitalCredentials: model.DigitalCredentialsConfig{Enable: tt.dcAPIEnabled},
 				},
 			}
 
@@ -86,6 +90,8 @@ func TestUIMetadata(t *testing.T) {
 
 			assert.NoError(t, err)
 			require.NotNil(t, reply)
+
+			assert.Equal(t, tt.dcAPIEnabled, reply.DCAPIEnabled, "DCAPIEnabled should mirror verifier.digital_credentials.enable")
 
 			if tt.expectCredentials == 0 {
 				assert.Len(t, reply.Credentials, 0)
@@ -296,11 +302,11 @@ func TestUIMetadataPresetFormatFromMetadata(t *testing.T) {
 // so the wallet discloses individual array elements instead of only the opaque parent.
 func TestAugmentDCQLFromVCTM_ArraySelectiveDisclosure(t *testing.T) {
 	tests := []struct {
-		name           string
-		vctmClaims     []sdjwtvc.Claim
-		inputClaims    []openid4vp.ClaimQuery
-		expectedPaths  [][]*string
-		removedPaths   [][]*string
+		name          string
+		vctmClaims    []sdjwtvc.Claim
+		inputClaims   []openid4vp.ClaimQuery
+		expectedPaths [][]*string
+		removedPaths  [][]*string
 	}{
 		{
 			name: "parent removed when array-element path present",
@@ -636,7 +642,7 @@ func TestAugmentDCQLFromVCTM_ComplexCredential(t *testing.T) {
 		inputClaims      []openid4vp.ClaimQuery
 		expectedPaths    [][]*string
 		expectedDCQLJSON []string // expected JSON for each claim after marshal
-		expectedValues   []any   // expected resolved values from the credential
+		expectedValues   []any    // expected resolved values from the credential
 	}{
 		{
 			name: "array of objects element field: degrees null type",

--- a/internal/verifier/staticembed/authorize_enhanced.html
+++ b/internal/verifier/staticembed/authorize_enhanced.html
@@ -390,13 +390,21 @@
         </div>
     </div>
 
+    <script type="importmap">
+    {
+        "imports": {
+            "@sirosfoundation/dc-api": "/static/dc-api.js"
+        }
+    }
+    </script>
     <script type="module">
         import { 
-            DigitalCredentialsClient, 
-            isDigitalCredentialsSupported,
-            isMobileDevice,
+            configure as configureDCAPI,
+            requestCredential,
+            isNativeDCAPIAvailable,
+            getBestSupportedProtocol,
             getUserFriendlyErrorMessage
-        } from '/static/digital-credentials.js';
+        } from '/static/dc-api-polyfill.js';
 
         // Configuration from server
         const config = {
@@ -412,6 +420,18 @@
             credentialDisplayRequired: {{.Config.CredentialDisplay.RequireConfirmation}}
         };
 
+        // Configure the DC API polyfill
+        configureDCAPI({
+            baseUrl: config.baseUrl,
+            sessionId: config.sessionId,
+            requestObjectUrl: config.useJAR
+                ? `${config.baseUrl}/verification/request-object/${config.sessionId}`
+                : undefined,
+            directPostUrl: `${config.baseUrl}/verification/direct_post`,
+            pollUrl: `${config.baseUrl}/poll/${config.sessionId}`,
+            deepLinkScheme: config.deepLinkScheme || 'openid4vp://',
+        });
+
         // UI elements
         const statusPending = document.getElementById('status-pending');
         const statusSuccess = document.getElementById('status-success');
@@ -426,9 +446,9 @@
         const btnShowQR = document.getElementById('btn-show-qr');
         const showCredentialDetailsCheckbox = document.getElementById('show-credential-details');
 
-        // Check browser capabilities
-        const hasDCSupport = isDigitalCredentialsSupported();
-        const isMobile = isMobileDevice();
+        // Check browser capabilities — DC API with openid4vp protocol support
+        const hasDCSupport = isNativeDCAPIAvailable() && getBestSupportedProtocol() !== null;
+        const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
         // Initialize UI based on capabilities
         function initializeUI() {
@@ -461,24 +481,64 @@
                 // Save credential display preference before invoking wallet
                 await saveDisplayPreference();
 
-                showLoader('Requesting credential from browser wallet...');
+                showLoader('Requesting credential from wallet...');
 
-                const client = new DigitalCredentialsClient({
-                    ...config,
-                    onProgress: (message) => {
-                        console.log('Progress:', message);
-                        showLoader(message);
-                    },
-                    onError: (error) => {
-                        console.error('DC API Error:', error);
-                        handleError(error);
-                    },
-                    onSuccess: (message) => {
-                        showSuccess(message);
-                    }
+                // Fetch the authorization request (signed JWT or plain object)
+                const endpoint = config.useJAR
+                    ? `/verification/request-object/${config.sessionId}`
+                    : `/verification/request/${config.sessionId}`;
+                const accept = config.useJAR
+                    ? 'application/oauth-authz-req+jwt'
+                    : 'application/json';
+
+                const reqResponse = await fetch(`${config.baseUrl}${endpoint}`, {
+                    method: 'GET',
+                    headers: { 'Accept': accept },
                 });
 
-                await client.requestCredential();
+                if (!reqResponse.ok) {
+                    throw new Error(`Failed to fetch authorization request: ${reqResponse.status}`);
+                }
+
+                const authRequest = config.useJAR
+                    ? await reqResponse.text()
+                    : await reqResponse.json();
+
+                // Use polyfill — it tries native DC API first, then falls back
+                const credential = await requestCredential(authRequest);
+
+                showLoader('Submitting credential...');
+
+                // Submit credential response to verifier
+                const body = new URLSearchParams({
+                    response: typeof credential.data === 'string'
+                        ? credential.data
+                        : JSON.stringify(credential.data),
+                    state: config.sessionId,
+                });
+
+                const submitResponse = await fetch(`${config.baseUrl}/verification/direct_post`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body,
+                });
+
+                if (!submitResponse.ok) {
+                    const errorText = await submitResponse.text();
+                    throw new Error(`Failed to submit credential: ${submitResponse.status} - ${errorText}`);
+                }
+
+                if (submitResponse.redirected) {
+                    window.location.href = submitResponse.url;
+                    return;
+                }
+
+                const result = await submitResponse.json();
+                if (result.redirect_uri) {
+                    window.location.href = result.redirect_uri;
+                } else {
+                    showSuccess('Credential verified successfully!');
+                }
 
             } catch (error) {
                 handleError(error);

--- a/internal/verifier/staticembed/dc-api-polyfill.js
+++ b/internal/verifier/staticembed/dc-api-polyfill.js
@@ -6,8 +6,9 @@
  *
  * Detection:
  *   (a) typeof DigitalCredential !== "undefined"  — DC API exists
- *   (b) DigitalCredential.userAgentAllowsProtocol("openid4vp-v1-unsigned")
- *       — browser allows the openid4vp presentation protocol
+ *   (b) DigitalCredential.userAgentAllowsProtocol("openid4vp-v1-signed")
+ *       — browser allows the signed openid4vp presentation protocol
+ *       (library auto-selects best: signed > multisigned > unsigned)
  *
  * If a wallet extension shims the DC API transparently, no special
  * handling is needed — the native path works the same way.

--- a/internal/verifier/staticembed/dc-api-polyfill.js
+++ b/internal/verifier/staticembed/dc-api-polyfill.js
@@ -19,19 +19,7 @@
  *   - Library: https://github.com/sirosfoundation/dc-api
  */
 
-// Re-export core library functions for consumers
-import {
-    OID4VP_PROTOCOLS,
-    isDCAPIAvailable,
-    isProtocolAllowed,
-    getBestProtocol,
-    requestCredential as dcApiRequestCredential,
-    getUserFriendlyErrorMessage,
-    isUserCancel,
-    isProtocolUnsupported,
-    ERROR_MESSAGES,
-} from '@sirosfoundation/dc-api';
-
+// Re-export core library symbols
 export {
     OID4VP_PROTOCOLS,
     isDCAPIAvailable,
@@ -40,7 +28,13 @@ export {
     isUserCancel,
     isProtocolUnsupported,
     ERROR_MESSAGES,
-};
+} from '@sirosfoundation/dc-api';
+
+import {
+    isDCAPIAvailable,
+    getBestProtocol,
+    requestCredential as dcApiRequestCredential,
+} from '@sirosfoundation/dc-api';
 
 // ─── Aliases for backward compat ─────────────────────────────────────────────
 
@@ -52,21 +46,30 @@ export const getBestSupportedProtocol = getBestProtocol;
 
 // ─── Mobile detection ────────────────────────────────────────────────────────
 
+const MOBILE_UA_RE = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
 /**
  * Detect mobile device from user agent.
  * @returns {boolean}
  */
 function isMobileDevice() {
-    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-    );
+    return MOBILE_UA_RE.test(globalThis.navigator?.userAgent ?? '');
+}
+
+// ─── SSE onError handler (outer scope per SonarCloud) ────────────────────────
+
+/**
+ * SSE error handler — SSE reconnects automatically; we only act on explicit abort.
+ */
+function _sseOnError() {
+    // SSE reconnects automatically; only reject on abort
 }
 
 // ─── Polyfill configuration ─────────────────────────────────────────────────
 
 /**
  * @typedef {Object} PolyfillConfig
- * @property {string}   baseUrl            Verifier origin (default: window.location.origin)
+ * @property {string}   baseUrl            Verifier origin (default: globalThis.location.origin)
  * @property {string}   [sessionId]        Session identifier for server-side correlation
  * @property {string}   [requestObjectUrl] URL to fetch signed JWT request object
  * @property {string}   [directPostUrl]    URL for wallet direct_post response
@@ -96,7 +99,7 @@ let _config = {
 export function configure(config) {
     _config = { ..._config, ...config };
     if (!_config.baseUrl) {
-        _config.baseUrl = window.location.origin;
+        _config.baseUrl = globalThis.location?.origin ?? '';
     }
 }
 
@@ -111,9 +114,8 @@ export function configure(config) {
  *   3. No DC API → polyfill fallback
  *
  * Polyfill fallback:
- *   a. Web wallet popup (if webWallets configured)
- *   b. Same-device redirect (openid4vp:// on mobile)
- *   c. Cross-device QR code + poll/SSE
+ *   a. Same-device redirect (openid4vp:// on mobile)
+ *   b. Cross-device QR code + poll/SSE
  *
  * @param {object} openid4vpRequest  The OpenID4VP authorization request object or signed JWT string
  * @param {object} [options]         Additional options
@@ -127,25 +129,18 @@ export async function requestCredential(openid4vpRequest, options = {}) {
 
         if (protocol) {
             try {
-                // Build data per protocol variant
-                let data;
-                if (typeof openid4vpRequest === 'string') {
-                    data = { request: openid4vpRequest };
-                } else {
-                    data = openid4vpRequest;
-                }
+                const data = typeof openid4vpRequest === 'string'
+                    ? { request: openid4vpRequest }
+                    : openid4vpRequest;
 
-                const result = await dcApiRequestCredential(protocol, data, options);
-                return result;
+                return await dcApiRequestCredential(protocol, data, options);
             } catch (err) {
                 // NotAllowedError → user cancelled or no wallet, fall through
                 if (err.name !== 'NotAllowedError') {
                     throw err;
                 }
-                // Fall through to polyfill
             }
         }
-        // protocol === null → DC API exists but no openid4vp variant allowed
     }
 
     // 2. Polyfill path — implement OpenID4VP transport ourselves
@@ -163,12 +158,9 @@ export async function requestCredential(openid4vpRequest, options = {}) {
  * @returns {Promise<{protocol: string, data: unknown}>}
  */
 async function _polyfillRequest(openid4vpRequest, options) {
-    // Same-device mobile: redirect to openid4vp:// scheme
     if (isMobileDevice() && _config.deepLinkScheme) {
         return _sameDeviceRedirect(openid4vpRequest, options);
     }
-
-    // Cross-device: wait for the wallet to respond via server-side
     return _crossDeviceWait(options);
 }
 
@@ -176,8 +168,6 @@ async function _polyfillRequest(openid4vpRequest, options) {
 
 /**
  * Redirect to openid4vp:// custom scheme for same-device mobile flow.
- * The wallet posts the VP token to the server's response_uri.
- * We wait for the server to notify us via SSE or polling.
  *
  * @param {object|string} openid4vpRequest
  * @param {object} options
@@ -187,16 +177,14 @@ async function _sameDeviceRedirect(openid4vpRequest, options) {
     let authRequestUri;
 
     if (typeof openid4vpRequest === 'string') {
+        const params = new URLSearchParams();
         if (_config.requestObjectUrl) {
-            const params = new URLSearchParams();
-            params.set('client_id', window.location.origin);
+            params.set('client_id', globalThis.location?.origin ?? '');
             params.set('request_uri', _config.requestObjectUrl);
-            authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
         } else {
-            const params = new URLSearchParams();
             params.set('request', openid4vpRequest);
-            authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
         }
+        authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
     } else {
         const params = new URLSearchParams();
         for (const [key, value] of Object.entries(openid4vpRequest)) {
@@ -207,7 +195,7 @@ async function _sameDeviceRedirect(openid4vpRequest, options) {
         authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
     }
 
-    window.location.href = authRequestUri;
+    globalThis.location.href = authRequestUri;
     return _crossDeviceWait(options);
 }
 
@@ -215,7 +203,6 @@ async function _sameDeviceRedirect(openid4vpRequest, options) {
 
 /**
  * Wait for the server to signal that the wallet has responded.
- * Uses SSE if sseUrl is configured, otherwise polls pollUrl.
  *
  * @param {object} options
  * @returns {Promise<{protocol: string, data: unknown}>}
@@ -231,6 +218,8 @@ function _crossDeviceWait(options) {
         new Error('No SSE or poll URL configured for cross-device flow'),
     );
 }
+
+const REDIRECT_URI_RE = /redirect_uri[=:]["']?([^"'\s]+)/;
 
 /**
  * Wait for server notification via SSE.
@@ -260,19 +249,15 @@ function _waitViaSSE(options) {
                     });
                 }
             } catch {
-                const match = data.match(/redirect_uri[=:]["']?([^"'\s]+)/);
-                if (match && match[1]) {
+                const result = REDIRECT_URI_RE.exec(data);
+                if (result?.[1]) {
                     cleanup();
                     resolve({
                         protocol: 'openid4vp',
-                        data: { redirect_uri: match[1] },
+                        data: { redirect_uri: result[1] },
                     });
                 }
             }
-        }
-
-        function onError() {
-            // SSE reconnects automatically; only reject on abort
         }
 
         function onAbort() {
@@ -283,16 +268,12 @@ function _waitViaSSE(options) {
         function cleanup() {
             clearTimeout(timeout);
             eventSource.close();
-            if (options.signal) {
-                options.signal.removeEventListener('abort', onAbort);
-            }
+            options.signal?.removeEventListener('abort', onAbort);
         }
 
         eventSource.onmessage = onMessage;
-        eventSource.onerror = onError;
-        if (options.signal) {
-            options.signal.addEventListener('abort', onAbort, { once: true });
-        }
+        eventSource.onerror = _sseOnError;
+        options.signal?.addEventListener('abort', onAbort, { once: true });
     });
 }
 
@@ -317,10 +298,7 @@ function _waitViaPoll(options) {
                 if (response.ok) {
                     const data = await response.json();
                     if (data.status === 'code_issued' || data.status === 'completed') {
-                        resolve({
-                            protocol: 'openid4vp',
-                            data,
-                        });
+                        resolve({ protocol: 'openid4vp', data });
                         return;
                     }
                     if (data.status === 'failed' || data.status === 'error') {
@@ -340,10 +318,7 @@ function _waitViaPoll(options) {
             reject(new DOMException('Request aborted', 'AbortError'));
         }
 
-        if (options.signal) {
-            options.signal.addEventListener('abort', onAbort, { once: true });
-        }
-
+        options.signal?.addEventListener('abort', onAbort, { once: true });
         poll();
     });
 }

--- a/internal/verifier/staticembed/dc-api-polyfill.js
+++ b/internal/verifier/staticembed/dc-api-polyfill.js
@@ -111,8 +111,19 @@ export function configure(config) {
  *
  * Decision tree:
  *   1. Native DC API + openid4vp protocol → use @sirosfoundation/dc-api
- *   2. Native DC API exists but openid4vp fails → polyfill fallback
- *   3. No DC API → polyfill fallback
+ *   2. No DC API, or the protocol isn't supported at all → polyfill fallback
+ *
+ * A native attempt that actually ran and failed (including the user
+ * dismissing/declining the picker, which surfaces as NotAllowedError) is
+ * NOT retried through the polyfill fallback here — it propagates to the
+ * caller instead. The polyfill fallback below can block for
+ * `_config.timeoutMs` (default 5 minutes) waiting on a cross-device
+ * SSE/poll response; silently entering that wait after the user already
+ * responded to the native picker left the page stuck on a loading spinner
+ * with no way to reach the traditional QR/wallet-link UI. Callers already
+ * handle a rejection here by falling back to their own QR/wallet-link UI
+ * immediately, which is the correct behavior for both "user declined" and
+ * "no wallet available" outcomes.
  *
  * Polyfill fallback:
  *   a. Same-device redirect (openid4vp:// on mobile)
@@ -129,22 +140,18 @@ export async function requestCredential(openid4vpRequest, options = {}) {
         const protocol = getBestProtocol();
 
         if (protocol) {
-            try {
-                const data = typeof openid4vpRequest === 'string'
-                    ? { request: openid4vpRequest }
-                    : openid4vpRequest;
+            const data = typeof openid4vpRequest === 'string'
+                ? { request: openid4vpRequest }
+                : openid4vpRequest;
 
-                return await dcApiRequestCredential(protocol, data, options);
-            } catch (err) {
-                // NotAllowedError → user cancelled or no wallet, fall through
-                if (err.name !== 'NotAllowedError') {
-                    throw err;
-                }
-            }
+            return await dcApiRequestCredential(protocol, data, options);
         }
     }
 
-    // 2. Polyfill path — implement OpenID4VP transport ourselves
+    // 2. Polyfill path — implement OpenID4VP transport ourselves.
+    // Only reached when native DC API isn't available or doesn't support
+    // any of our preferred protocols — never as a retry after a native
+    // attempt that actually ran.
     return _polyfillRequest(openid4vpRequest, options);
 }
 

--- a/internal/verifier/staticembed/dc-api-polyfill.js
+++ b/internal/verifier/staticembed/dc-api-polyfill.js
@@ -1,0 +1,387 @@
+/**
+ * Verifier DC API integration — OpenID4VP over the W3C Digital Credentials API
+ *
+ * Imports core DC API utilities from @sirosfoundation/dc-api and adds
+ * verifier-specific transport fallbacks (redirect, QR, SSE/poll).
+ *
+ * Detection:
+ *   (a) typeof DigitalCredential !== "undefined"  — DC API exists
+ *   (b) DigitalCredential.userAgentAllowsProtocol("openid4vp-v1-unsigned")
+ *       — browser allows the openid4vp presentation protocol
+ *
+ * If a wallet extension shims the DC API transparently, no special
+ * handling is needed — the native path works the same way.
+ *
+ * References:
+ *   - W3C Digital Credentials API: https://w3c-fedid.github.io/digital-credentials/
+ *   - OpenID4VP Appendix A (DC API profile): https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+ *   - CS-007: Credential Presentation via the Digital Credentials API
+ *   - Library: https://github.com/sirosfoundation/dc-api
+ */
+
+// Re-export core library functions for consumers
+import {
+    OID4VP_PROTOCOLS,
+    isDCAPIAvailable,
+    isProtocolAllowed,
+    getBestProtocol,
+    requestCredential as dcApiRequestCredential,
+    getUserFriendlyErrorMessage,
+    isUserCancel,
+    isProtocolUnsupported,
+    ERROR_MESSAGES,
+} from '@sirosfoundation/dc-api';
+
+export {
+    OID4VP_PROTOCOLS,
+    isDCAPIAvailable,
+    isProtocolAllowed,
+    getUserFriendlyErrorMessage,
+    isUserCancel,
+    isProtocolUnsupported,
+    ERROR_MESSAGES,
+};
+
+// ─── Aliases for backward compat ─────────────────────────────────────────────
+
+/** Alias for isDCAPIAvailable (used by existing verifier code) */
+export const isNativeDCAPIAvailable = isDCAPIAvailable;
+
+/** Alias for getBestProtocol (used by existing verifier code) */
+export const getBestSupportedProtocol = getBestProtocol;
+
+// ─── Mobile detection ────────────────────────────────────────────────────────
+
+/**
+ * Detect mobile device from user agent.
+ * @returns {boolean}
+ */
+function isMobileDevice() {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+        navigator.userAgent
+    );
+}
+
+// ─── Polyfill configuration ─────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} PolyfillConfig
+ * @property {string}   baseUrl            Verifier origin (default: window.location.origin)
+ * @property {string}   [sessionId]        Session identifier for server-side correlation
+ * @property {string}   [requestObjectUrl] URL to fetch signed JWT request object
+ * @property {string}   [directPostUrl]    URL for wallet direct_post response
+ * @property {string}   [qrCodeUrl]        URL to fetch QR code image
+ * @property {string}   [pollUrl]          URL to poll for cross-device response
+ * @property {string}   [sseUrl]           URL for SSE notifications
+ * @property {Record<string,string>} [webWallets] Map of wallet name → wallet URL
+ * @property {string}   [deepLinkScheme]   Custom URL scheme (default: "openid4vp://")
+ * @property {boolean}  [preferNative]     Try native DC API first (default: true)
+ * @property {number}   [pollIntervalMs]   Polling interval in ms (default: 2000)
+ * @property {number}   [timeoutMs]        Overall timeout in ms (default: 300000)
+ */
+
+/** @type {PolyfillConfig} */
+let _config = {
+    baseUrl: '',
+    deepLinkScheme: 'openid4vp://',
+    preferNative: true,
+    pollIntervalMs: 2000,
+    timeoutMs: 300000,
+};
+
+/**
+ * Configure the polyfill. Call before using requestCredential().
+ * @param {Partial<PolyfillConfig>} config
+ */
+export function configure(config) {
+    _config = { ..._config, ...config };
+    if (!_config.baseUrl) {
+        _config.baseUrl = window.location.origin;
+    }
+}
+
+// ─── Core: requestCredential ────────────────────────────────────────────────
+
+/**
+ * Request a credential presentation using the DC API surface.
+ *
+ * Decision tree:
+ *   1. Native DC API + openid4vp protocol → use @sirosfoundation/dc-api
+ *   2. Native DC API exists but openid4vp fails → polyfill fallback
+ *   3. No DC API → polyfill fallback
+ *
+ * Polyfill fallback:
+ *   a. Web wallet popup (if webWallets configured)
+ *   b. Same-device redirect (openid4vp:// on mobile)
+ *   c. Cross-device QR code + poll/SSE
+ *
+ * @param {object} openid4vpRequest  The OpenID4VP authorization request object or signed JWT string
+ * @param {object} [options]         Additional options
+ * @param {AbortSignal} [options.signal]  AbortSignal for cancellation
+ * @returns {Promise<{protocol: string, data: unknown}>}  DigitalCredential-shaped response
+ */
+export async function requestCredential(openid4vpRequest, options = {}) {
+    // 1. Try native DC API via the library if available and preferred
+    if (_config.preferNative && isDCAPIAvailable()) {
+        const protocol = getBestProtocol();
+
+        if (protocol) {
+            try {
+                // Build data per protocol variant
+                let data;
+                if (typeof openid4vpRequest === 'string') {
+                    data = { request: openid4vpRequest };
+                } else {
+                    data = openid4vpRequest;
+                }
+
+                const result = await dcApiRequestCredential(protocol, data, options);
+                return result;
+            } catch (err) {
+                // NotAllowedError → user cancelled or no wallet, fall through
+                if (err.name !== 'NotAllowedError') {
+                    throw err;
+                }
+                // Fall through to polyfill
+            }
+        }
+        // protocol === null → DC API exists but no openid4vp variant allowed
+    }
+
+    // 2. Polyfill path — implement OpenID4VP transport ourselves
+    return _polyfillRequest(openid4vpRequest, options);
+}
+
+// ─── Polyfill fallback path ─────────────────────────────────────────────────
+
+/**
+ * Implement OpenID4VP transport when native DC API is unavailable or
+ * doesn't support the openid4vp protocol.
+ *
+ * @param {object|string} openid4vpRequest
+ * @param {object} options
+ * @returns {Promise<{protocol: string, data: unknown}>}
+ */
+async function _polyfillRequest(openid4vpRequest, options) {
+    // Same-device mobile: redirect to openid4vp:// scheme
+    if (isMobileDevice() && _config.deepLinkScheme) {
+        return _sameDeviceRedirect(openid4vpRequest, options);
+    }
+
+    // Cross-device: wait for the wallet to respond via server-side
+    return _crossDeviceWait(options);
+}
+
+// ─── Transport: Same-device redirect ────────────────────────────────────────
+
+/**
+ * Redirect to openid4vp:// custom scheme for same-device mobile flow.
+ * The wallet posts the VP token to the server's response_uri.
+ * We wait for the server to notify us via SSE or polling.
+ *
+ * @param {object|string} openid4vpRequest
+ * @param {object} options
+ * @returns {Promise<{protocol: string, data: unknown}>}
+ */
+async function _sameDeviceRedirect(openid4vpRequest, options) {
+    let authRequestUri;
+
+    if (typeof openid4vpRequest === 'string') {
+        if (_config.requestObjectUrl) {
+            const params = new URLSearchParams();
+            params.set('client_id', window.location.origin);
+            params.set('request_uri', _config.requestObjectUrl);
+            authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
+        } else {
+            const params = new URLSearchParams();
+            params.set('request', openid4vpRequest);
+            authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
+        }
+    } else {
+        const params = new URLSearchParams();
+        for (const [key, value] of Object.entries(openid4vpRequest)) {
+            if (value !== undefined && value !== null) {
+                params.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+            }
+        }
+        authRequestUri = `${_config.deepLinkScheme}?${params.toString()}`;
+    }
+
+    window.location.href = authRequestUri;
+    return _crossDeviceWait(options);
+}
+
+// ─── Transport: Cross-device wait (SSE / poll) ─────────────────────────────
+
+/**
+ * Wait for the server to signal that the wallet has responded.
+ * Uses SSE if sseUrl is configured, otherwise polls pollUrl.
+ *
+ * @param {object} options
+ * @returns {Promise<{protocol: string, data: unknown}>}
+ */
+function _crossDeviceWait(options) {
+    if (_config.sseUrl) {
+        return _waitViaSSE(options);
+    }
+    if (_config.pollUrl) {
+        return _waitViaPoll(options);
+    }
+    return Promise.reject(
+        new Error('No SSE or poll URL configured for cross-device flow'),
+    );
+}
+
+/**
+ * Wait for server notification via SSE.
+ * @param {object} options
+ * @returns {Promise<{protocol: string, data: unknown}>}
+ */
+function _waitViaSSE(options) {
+    return new Promise((resolve, reject) => {
+        const eventSource = new EventSource(_config.sseUrl);
+
+        const timeout = setTimeout(() => {
+            cleanup();
+            reject(new DOMException('Timeout waiting for wallet response', 'AbortError'));
+        }, _config.timeoutMs);
+
+        function onMessage(event) {
+            const data = event.data;
+            if (!data || typeof data !== 'string') return;
+
+            try {
+                const parsed = JSON.parse(data);
+                if (parsed.redirect_uri) {
+                    cleanup();
+                    resolve({
+                        protocol: 'openid4vp',
+                        data: { redirect_uri: parsed.redirect_uri },
+                    });
+                }
+            } catch {
+                const match = data.match(/redirect_uri[=:]["']?([^"'\s]+)/);
+                if (match && match[1]) {
+                    cleanup();
+                    resolve({
+                        protocol: 'openid4vp',
+                        data: { redirect_uri: match[1] },
+                    });
+                }
+            }
+        }
+
+        function onError() {
+            // SSE reconnects automatically; only reject on abort
+        }
+
+        function onAbort() {
+            cleanup();
+            reject(new DOMException('Request aborted', 'AbortError'));
+        }
+
+        function cleanup() {
+            clearTimeout(timeout);
+            eventSource.close();
+            if (options.signal) {
+                options.signal.removeEventListener('abort', onAbort);
+            }
+        }
+
+        eventSource.onmessage = onMessage;
+        eventSource.onerror = onError;
+        if (options.signal) {
+            options.signal.addEventListener('abort', onAbort, { once: true });
+        }
+    });
+}
+
+/**
+ * Wait for server notification via polling.
+ * @param {object} options
+ * @returns {Promise<{protocol: string, data: unknown}>}
+ */
+function _waitViaPoll(options) {
+    return new Promise((resolve, reject) => {
+        const deadline = Date.now() + _config.timeoutMs;
+        let timer;
+
+        async function poll() {
+            if (Date.now() > deadline) {
+                reject(new DOMException('Timeout waiting for wallet response', 'AbortError'));
+                return;
+            }
+
+            try {
+                const response = await fetch(_config.pollUrl);
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.status === 'code_issued' || data.status === 'completed') {
+                        resolve({
+                            protocol: 'openid4vp',
+                            data,
+                        });
+                        return;
+                    }
+                    if (data.status === 'failed' || data.status === 'error') {
+                        reject(new Error(data.error || 'Verification failed'));
+                        return;
+                    }
+                }
+            } catch {
+                // Network error — retry
+            }
+
+            timer = setTimeout(poll, _config.pollIntervalMs);
+        }
+
+        function onAbort() {
+            clearTimeout(timer);
+            reject(new DOMException('Request aborted', 'AbortError'));
+        }
+
+        if (options.signal) {
+            options.signal.addEventListener('abort', onAbort, { once: true });
+        }
+
+        poll();
+    });
+}
+
+// ─── Verifier helpers ───────────────────────────────────────────────────────
+
+/**
+ * Get the configured QR code image URL, if available.
+ * @returns {string|null}
+ */
+export function getQRCodeUrl() {
+    return _config.qrCodeUrl || null;
+}
+
+/**
+ * Get the configured deep link URI for same-device flow.
+ * @param {string} authorizationRequest  The authorization_request URI from the server
+ * @returns {string}
+ */
+export function getDeepLinkUrl(authorizationRequest) {
+    const presDefURI = new URL(authorizationRequest);
+    return `${_config.deepLinkScheme || 'openid4vp://'}${presDefURI.search}${presDefURI.hash}`;
+}
+
+/**
+ * Build web wallet URLs from configured wallets + authorization request.
+ * @param {string} authorizationRequest  The authorization_request URI from the server
+ * @returns {Record<string, string>}  Map of wallet label → invocation URL
+ */
+export function getWebWalletUrls(authorizationRequest) {
+    if (!_config.webWallets) return {};
+    const presDefURI = new URL(authorizationRequest);
+    const urls = {};
+    for (const [label, baseUrl] of Object.entries(_config.webWallets)) {
+        const uri = new URL(baseUrl);
+        uri.search = presDefURI.search;
+        uri.hash = presDefURI.hash;
+        urls[`Open with ${label}`] = uri.toString();
+    }
+    return urls;
+}

--- a/internal/verifier/staticembed/dc-api.js
+++ b/internal/verifier/staticembed/dc-api.js
@@ -18,6 +18,9 @@ const OID4VP_ALL_PROTOCOLS = [
   ...OID4VP_SPEC_PROTOCOLS,
   OID4VP_PROTOCOLS.LEGACY
 ];
+function isOID4VPProtocol(value) {
+  return OID4VP_ALL_PROTOCOLS.includes(value);
+}
 
 // src/detect.ts
 function isDCAPIAvailable() {
@@ -95,10 +98,13 @@ function isProtocolUnsupported(error) {
 }
 export {
   ERROR_MESSAGES,
+  OID4VP_ALL_PROTOCOLS,
   OID4VP_PROTOCOLS,
+  OID4VP_SPEC_PROTOCOLS,
   getBestProtocol,
   getUserFriendlyErrorMessage,
   isDCAPIAvailable,
+  isOID4VPProtocol,
   isProtocolAllowed,
   isProtocolUnsupported,
   isUserCancel,

--- a/internal/verifier/staticembed/dc-api.js
+++ b/internal/verifier/staticembed/dc-api.js
@@ -1,5 +1,5 @@
 // src/protocols.ts
-var OID4VP_PROTOCOLS = {
+const OID4VP_PROTOCOLS = {
   /** Unsigned request — client_id derived from web-origin */
   UNSIGNED: "openid4vp-v1-unsigned",
   /** Signed request — JAR with single JWS compact serialization */
@@ -9,12 +9,12 @@ var OID4VP_PROTOCOLS = {
   /** Legacy protocol string (pre-spec, used by some implementations) */
   LEGACY: "openid4vp"
 };
-var OID4VP_SPEC_PROTOCOLS = [
+const OID4VP_SPEC_PROTOCOLS = [
   OID4VP_PROTOCOLS.UNSIGNED,
   OID4VP_PROTOCOLS.SIGNED,
   OID4VP_PROTOCOLS.MULTISIGNED
 ];
-var OID4VP_ALL_PROTOCOLS = [
+const OID4VP_ALL_PROTOCOLS = [
   ...OID4VP_SPEC_PROTOCOLS,
   OID4VP_PROTOCOLS.LEGACY
 ];
@@ -28,7 +28,7 @@ function isProtocolAllowed(protocol) {
   if (typeof DigitalCredential.userAgentAllowsProtocol !== "function") return false;
   return DigitalCredential.userAgentAllowsProtocol(protocol);
 }
-var DEFAULT_PREFERENCE = [
+const DEFAULT_PREFERENCE = [
   OID4VP_PROTOCOLS.SIGNED,
   OID4VP_PROTOCOLS.MULTISIGNED,
   OID4VP_PROTOCOLS.UNSIGNED
@@ -69,7 +69,7 @@ function normalizeCredential(credential, fallbackProtocol) {
 }
 
 // src/errors.ts
-var ERROR_MESSAGES = {
+const ERROR_MESSAGES = {
   NotAllowedError: "You denied the credential request or no wallet is available.",
   NotSupportedError: "Your browser or wallet does not support this credential type.",
   SecurityError: "Security error \u2014 ensure you are on HTTPS.",
@@ -77,7 +77,7 @@ var ERROR_MESSAGES = {
   InvalidStateError: "A credential request is already in progress.",
   TypeError: "The credential request data is malformed."
 };
-var DEFAULT_MESSAGE = "An unexpected error occurred. Please try again.";
+const DEFAULT_MESSAGE = "An unexpected error occurred. Please try again.";
 function getUserFriendlyErrorMessage(error) {
   if (error instanceof DOMException) {
     return ERROR_MESSAGES[error.name] ?? DEFAULT_MESSAGE;

--- a/internal/verifier/staticembed/dc-api.js
+++ b/internal/verifier/staticembed/dc-api.js
@@ -1,0 +1,106 @@
+// src/protocols.ts
+var OID4VP_PROTOCOLS = {
+  /** Unsigned request — client_id derived from web-origin */
+  UNSIGNED: "openid4vp-v1-unsigned",
+  /** Signed request — JAR with single JWS compact serialization */
+  SIGNED: "openid4vp-v1-signed",
+  /** Multi-signed request — JWS JSON serialization */
+  MULTISIGNED: "openid4vp-v1-multisigned",
+  /** Legacy protocol string (pre-spec, used by some implementations) */
+  LEGACY: "openid4vp"
+};
+var OID4VP_SPEC_PROTOCOLS = [
+  OID4VP_PROTOCOLS.UNSIGNED,
+  OID4VP_PROTOCOLS.SIGNED,
+  OID4VP_PROTOCOLS.MULTISIGNED
+];
+var OID4VP_ALL_PROTOCOLS = [
+  ...OID4VP_SPEC_PROTOCOLS,
+  OID4VP_PROTOCOLS.LEGACY
+];
+
+// src/detect.ts
+function isDCAPIAvailable() {
+  return typeof DigitalCredential !== "undefined";
+}
+function isProtocolAllowed(protocol) {
+  if (typeof DigitalCredential === "undefined") return false;
+  if (typeof DigitalCredential.userAgentAllowsProtocol !== "function") return false;
+  return DigitalCredential.userAgentAllowsProtocol(protocol);
+}
+var DEFAULT_PREFERENCE = [
+  OID4VP_PROTOCOLS.SIGNED,
+  OID4VP_PROTOCOLS.MULTISIGNED,
+  OID4VP_PROTOCOLS.UNSIGNED
+];
+function getBestProtocol(preference) {
+  const candidates = preference ?? DEFAULT_PREFERENCE;
+  for (const proto of candidates) {
+    if (isProtocolAllowed(proto)) return proto;
+  }
+  return null;
+}
+
+// src/request.ts
+async function requestCredential(protocol, data, options) {
+  const dcOptions = {
+    digital: {
+      requests: [{
+        protocol,
+        data
+      }]
+    }
+  };
+  if (options?.signal) {
+    dcOptions.signal = options.signal;
+  }
+  const credential = await navigator.credentials.get(dcOptions);
+  if (!credential) {
+    throw new DOMException("No credential received", "NotAllowedError");
+  }
+  return normalizeCredential(credential, protocol);
+}
+function normalizeCredential(credential, fallbackProtocol) {
+  const dc = credential;
+  return {
+    protocol: dc.protocol ?? fallbackProtocol,
+    data: dc.data ?? credential
+  };
+}
+
+// src/errors.ts
+var ERROR_MESSAGES = {
+  NotAllowedError: "You denied the credential request or no wallet is available.",
+  NotSupportedError: "Your browser or wallet does not support this credential type.",
+  SecurityError: "Security error \u2014 ensure you are on HTTPS.",
+  AbortError: "The request was cancelled or timed out.",
+  InvalidStateError: "A credential request is already in progress.",
+  TypeError: "The credential request data is malformed."
+};
+var DEFAULT_MESSAGE = "An unexpected error occurred. Please try again.";
+function getUserFriendlyErrorMessage(error) {
+  if (error instanceof DOMException) {
+    return ERROR_MESSAGES[error.name] ?? DEFAULT_MESSAGE;
+  }
+  if (error instanceof Error) {
+    return ERROR_MESSAGES[error.name] ?? DEFAULT_MESSAGE;
+  }
+  return DEFAULT_MESSAGE;
+}
+function isUserCancel(error) {
+  return error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "AbortError");
+}
+function isProtocolUnsupported(error) {
+  return error instanceof DOMException && error.name === "NotSupportedError";
+}
+export {
+  ERROR_MESSAGES,
+  OID4VP_PROTOCOLS,
+  getBestProtocol,
+  getUserFriendlyErrorMessage,
+  isDCAPIAvailable,
+  isProtocolAllowed,
+  isProtocolUnsupported,
+  isUserCancel,
+  requestCredential
+};

--- a/internal/verifier/staticembed/presentation-definition.html
+++ b/internal/verifier/staticembed/presentation-definition.html
@@ -10,7 +10,9 @@
     {
         "imports": {
             "alpinejs": "/static/alpinejs.esm.min.js",
-            "valibot": "/static/valibot.min.js"
+            "valibot": "/static/valibot.min.js",
+            "@sirosfoundation/dc-api": "/static/dc-api.js",
+            "./dc-api-polyfill.js": "/static/dc-api-polyfill.js"
         }
     }
     </script>

--- a/internal/verifier/staticembed/presentation-definition.html
+++ b/internal/verifier/staticembed/presentation-definition.html
@@ -52,8 +52,9 @@
                     <h2 class="title is-size-6">Create custom presentation requests</h2>
                     <form x-ref="credentialSelectionForm" @submit.prevent="handleCredentialSelectionForm">
                         <div class="field block">
+                            <label for="credential-select" class="is-sr-only">Credential type</label>
                             <div class="select is-fullwidth">
-                                <select name="credential" required>
+                                <select id="credential-select" name="credential" required>
                                     <option disabled selected>Choose type of credential to verify</option>
                                     <template x-for="[id, credAttrs] in Object.entries(credentialsList)">
                                         <option :value="id" x-text="credAttrs.vct">
@@ -91,7 +92,7 @@
                                                 <details class="vc-claim-group" open>
                                                     <summary class="vc-claim-group-summary">
                                                         <label class="checkbox" @click.stop>
-                                                            <input type="checkbox" 
+                                                            <input type="checkbox" aria-label="Toggle all child attributes"
                                                                 @change="$el.closest('.vc-claim-group').querySelectorAll(':scope > ul input[type=checkbox]').forEach(cb => cb.checked = $el.checked)" />
                                                             <strong x-text="node.label"></strong>
                                                         </label>

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -5,9 +5,6 @@ import {
     requestCredential,
     isNativeDCAPIAvailable,
     getBestSupportedProtocol,
-    getDeepLinkUrl,
-    getWebWalletUrls,
-    getUserFriendlyErrorMessage,
 } from "./dc-api-polyfill.js";
 
 /** @typedef {v.InferOutput<typeof credentialAttributesSchema>} CredentialAttributes */
@@ -474,51 +471,60 @@ Alpine.data("app", () => ({
                 webWallets: this.walletInstances,
             });
 
-            // Try native DC API first — if the browser supports
-            // an openid4vp protocol variant, use it directly.
-            if (isNativeDCAPIAvailable() && getBestSupportedProtocol()) {
-                try {
-                    const abortController = new AbortController();
-                    this._dcAbort = abortController;
-
-                    const result = await requestCredential(
-                        this.presentationDefinition.authorization_request,
-                        { signal: abortController.signal },
-                    );
-
-                    // Native DC API succeeded — handle redirect from response
-                    if (result.data && result.data.redirect_uri) {
-                        window.location.href = result.data.redirect_uri;
-                        return;
-                    }
-                    // If no redirect in response, the wallet posted directly
-                    // to the server — wait for SSE notification below
-                } catch (err) {
-                    if (err.name === 'AbortError') return;
-                    console.log("DC API not available or failed, falling back to QR/links:", err.message);
-                    // Fall through to QR + wallet links
-                }
-            }
+            // Try native DC API first
+            if (await this._tryNativeDCAPI()) return;
 
             // Fallback: show QR code + wallet links + SSE listener
-            if (!this.notifyEventSource) {
-                console.log("Starting SSE notify listener from sendDcqlQuery");
-                this.notifyEventSource = setupNotifyListener();
-            }
-
-            const presDefURI = new URL(this.presentationDefinition.authorization_request);
-
-            for (const [label, url] of Object.entries(this.walletInstances)) {
-                const uri = new URL(url);
-                uri.search = presDefURI.search;
-                uri.hash = presDefURI.hash;
-
-                if (!this.redirectUris) this.redirectUris = {};
-                this.redirectUris[`Open with ${label}`] = uri.toString();
-            }
+            this._setupFallbackFlow();
         } catch (error) {
             this.error = `Error during posting of dcql query: ${error}`;
-            return;
+        }
+    },
+
+    /**
+     * Attempt credential request via native DC API.
+     * @returns {Promise<boolean>} true if handled, false to fall through
+     */
+    async _tryNativeDCAPI() {
+        if (!isNativeDCAPIAvailable() || !getBestSupportedProtocol()) return false;
+
+        try {
+            const abortController = new AbortController();
+            this._dcAbort = abortController;
+
+            const result = await requestCredential(
+                this.presentationDefinition.authorization_request,
+                { signal: abortController.signal },
+            );
+
+            if (result.data?.redirect_uri) {
+                globalThis.location.href = result.data.redirect_uri;
+                return true;
+            }
+            return false;
+        } catch (err) {
+            if (err.name === 'AbortError') return true;
+            console.log("DC API not available or failed, falling back to QR/links:", err.message);
+            return false;
+        }
+    },
+
+    /** Set up QR + wallet links + SSE fallback flow. */
+    _setupFallbackFlow() {
+        if (!this.notifyEventSource) {
+            console.log("Starting SSE notify listener from sendDcqlQuery");
+            this.notifyEventSource = setupNotifyListener();
+        }
+
+        const presDefURI = new URL(this.presentationDefinition.authorization_request);
+
+        for (const [label, url] of Object.entries(this.walletInstances)) {
+            const uri = new URL(url);
+            uri.search = presDefURI.search;
+            uri.hash = presDefURI.hash;
+
+            if (!this.redirectUris) this.redirectUris = {};
+            this.redirectUris[`Open with ${label}`] = uri.toString();
         }
     },
 

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -84,6 +84,7 @@ const credentialsList = v.record(
 const metadataResponseSchema = v.object({
     credentials: credentialsList,
     supported_wallets: v.record(v.string(), v.string()),
+    dc_api_enabled: v.optional(v.boolean(), false),
     presets: v.optional(v.record(v.string(), v.object({
         label: v.string(),
         credentials: v.array(v.object({
@@ -207,6 +208,9 @@ Alpine.data("app", () => ({
     /** @type {Record<string, string> | null} */
     walletInstances: null,
 
+    /** @type {boolean} Whether the server has opted in to native DC API attempts. */
+    dcApiEnabled: false,
+
      /** @type {{ id: string; vct: string; claims: Record<string, (string|null)[]>; claimTree: ClaimNode[]; } | null} */
     credentialAttributes: null,
 
@@ -250,6 +254,7 @@ Alpine.data("app", () => ({
 
         this.credentialsList = data.credentials;
         this.walletInstances = data.supported_wallets;
+        this.dcApiEnabled = data.dc_api_enabled;
 
         // Load presets from backend config
         if (data.presets) {
@@ -486,6 +491,7 @@ Alpine.data("app", () => ({
      * @returns {Promise<boolean>} true if handled, false to fall through
      */
     async _tryNativeDCAPI() {
+        if (!this.dcApiEnabled) return false;
         if (!isNativeDCAPIAvailable() || !getBestSupportedProtocol()) return false;
 
         try {

--- a/internal/verifier/staticembed/presentation-definition.js
+++ b/internal/verifier/staticembed/presentation-definition.js
@@ -1,5 +1,14 @@
 import Alpine from "alpinejs";
 import * as v from "valibot";
+import {
+    configure as configureDCAPI,
+    requestCredential,
+    isNativeDCAPIAvailable,
+    getBestSupportedProtocol,
+    getDeepLinkUrl,
+    getWebWalletUrls,
+    getUserFriendlyErrorMessage,
+} from "./dc-api-polyfill.js";
 
 /** @typedef {v.InferOutput<typeof credentialAttributesSchema>} CredentialAttributes */
 const credentialAttributesSchema = v.object({
@@ -456,25 +465,55 @@ Alpine.data("app", () => ({
                 },
             );
 
-            // Start SSE listener AFTER interaction call sets session_id
+            this.presentationDefinition = v.parse(presentationDefinitionSchema, res);
+
+            // Configure the DC API polyfill with server-side session info
+            configureDCAPI({
+                baseUrl: baseUrl.toString(),
+                sseUrl: new URL("/ui/notify", baseUrl).toString(),
+                webWallets: this.walletInstances,
+            });
+
+            // Try native DC API first — if the browser supports
+            // an openid4vp protocol variant, use it directly.
+            if (isNativeDCAPIAvailable() && getBestSupportedProtocol()) {
+                try {
+                    const abortController = new AbortController();
+                    this._dcAbort = abortController;
+
+                    const result = await requestCredential(
+                        this.presentationDefinition.authorization_request,
+                        { signal: abortController.signal },
+                    );
+
+                    // Native DC API succeeded — handle redirect from response
+                    if (result.data && result.data.redirect_uri) {
+                        window.location.href = result.data.redirect_uri;
+                        return;
+                    }
+                    // If no redirect in response, the wallet posted directly
+                    // to the server — wait for SSE notification below
+                } catch (err) {
+                    if (err.name === 'AbortError') return;
+                    console.log("DC API not available or failed, falling back to QR/links:", err.message);
+                    // Fall through to QR + wallet links
+                }
+            }
+
+            // Fallback: show QR code + wallet links + SSE listener
             if (!this.notifyEventSource) {
                 console.log("Starting SSE notify listener from sendDcqlQuery");
                 this.notifyEventSource = setupNotifyListener();
-                console.log("SSE notify listener started, eventSource:", this.notifyEventSource);
             }
-
-            this.presentationDefinition = v.parse(presentationDefinitionSchema, res);
 
             const presDefURI = new URL(this.presentationDefinition.authorization_request);
 
             for (const [label, url] of Object.entries(this.walletInstances)) {
                 const uri = new URL(url);
-
-                uri.search = presDefURI.search
-                uri.hash = presDefURI.hash
+                uri.search = presDefURI.search;
+                uri.hash = presDefURI.hash;
 
                 if (!this.redirectUris) this.redirectUris = {};
-
                 this.redirectUris[`Open with ${label}`] = uri.toString();
             }
         } catch (error) {

--- a/pkg/model/auth_providers.go
+++ b/pkg/model/auth_providers.go
@@ -4,4 +4,5 @@ const (
 	AuthProviderSAML      = "saml"
 	AuthProviderOIDC      = "oidc"
 	AuthProviderOpenID4VP = "openid4vp"
+	AuthProviderDatastore = "datastore"
 )


### PR DESCRIPTION
## Summary

Integrates the W3C Digital Credentials API (DC API) into the vc verifier via the `@sirosfoundation/dc-api` polyfill package.

## What changed

- **`internal/verifier/staticembed/dc-api-polyfill.js`** / **`dc-api.js`**: Vendor the DC API browser polyfill for environments without native support
- **`internal/verifier/staticembed/presentation-definition.html/js`**: Wire up DC API credential request path in the verifier presentation flow
- **`internal/verifier/apiv1/`**: Add handler support for DC API credential presentation
- **`Makefile`**: Add target to update the vendored DC API bundle

## Why

The W3C Digital Credentials API is now supported in Chrome and is being rolled out across browsers. This change allows the vc verifier to request credentials via the browser-native API instead of QR-code-only flows, enabling a direct tap-to-present UX.

## Testing

SonarCloud quality gate issues resolved (commit `a323ed65`). Vendored bundle updated to v0.2.0 (commit `dc5bd4da`).